### PR TITLE
Build pyepics v3.3.0 with epics-base

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,22 @@ source:
    sha256: {{ sha256 }}
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
   skip: True # [py<36]
+  script: |
+    export PYEPICS_LIBCA=$PREFIX/lib/libca.so  # [not win]
+    export NOLIBCA=1  # [not win]
+    echo "Using LIBCA from $PYEPICS_LIBCA"  # [not win]
+    python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
     - python
+    - epics-base
     - setuptools
   run:
     - python
+    - epics-base
     - numpy
     - pyparsing
     - setuptools  # needed to import pkg_resources


### PR DESCRIPTION
Need to use `epics-base` as a dependency and add some env vars as in https://github.com/NSLS-II/lightsource2-recipes/commit/3c4abb9f43686885e067077a9544b042dd4c1c51#diff-0b41cffe7ee3e72452ae99b54fffb04f.